### PR TITLE
Do not display the attached images, nor the delete fields if the rela…

### DIFF
--- a/app/views/trestle/active_storage/_has_many_field.html.erb
+++ b/app/views/trestle/active_storage/_has_many_field.html.erb
@@ -1,7 +1,7 @@
 <div class='nested-fields-container'>
   <%= builder.fields_for field_name do %>
     <div class="active-storage">
-      <% if attachments.attached? %>
+      <% if attachments.attached? && builder.object.persisted?  %>
         <% attachments.each do |attachment| %>
           <div class="active-storage__preview">
             <% if attachment.previewable? %>

--- a/app/views/trestle/active_storage/_has_one_field.html.erb
+++ b/app/views/trestle/active_storage/_has_one_field.html.erb
@@ -1,5 +1,5 @@
 <div class="active-storage">
-  <% if attachment.attached? %>
+  <% if attachment.attached? && builder.object.persisted? %>
     <div class="active-storage__preview">
       <% if attachment.previewable? %>
         <%= link_to image_tag(main_app.url_for(attachment.preview(resize: "300x300>")), class: "active-storage__image"),


### PR DESCRIPTION
…ted object has not been saved.

This is the simplest solution I arrived out. Basically, there isn't any value in displaying the image, nor the delete fields, if the attachments related object has not been saved. 