### PR TITLE
Upgrade dependency to trestle >= 0.9.3 with new controller

### DIFF
--- a/lib/trestle/active_storage/engine.rb
+++ b/lib/trestle/active_storage/engine.rb
@@ -3,10 +3,13 @@ module Trestle
     class Engine < Rails::Engine
       config.assets.precompile << 'activestorage.js' << 'trestle/active_storage_fields.js'
 
+      config.to_prepare do
+        Trestle::ResourceController.send(:prepend, Trestle::ActiveStorage::ControllerConcern)
+      end
+
       initializer :extensions do
         Trestle::Resource.send(:include, Trestle::ActiveStorage::Resource)
         Trestle::Resource::Builder.send(:include, Trestle::ActiveStorage::Builder)
-        Trestle::Resource::Controller.send(:include, Trestle::ActiveStorage::ControllerConcern)
       end
     end
   end

--- a/trestle-active_storage.gemspec
+++ b/trestle-active_storage.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'rails', '>= 5.2', '< 7'
-  s.add_dependency 'trestle', '~> 0.8'
+  s.add_dependency "trestle", "~> 0.9.0", ">= 0.9.3"
 end


### PR DESCRIPTION
The new version of trestle break the application because the controller management has changed, the fix is simple but need to be strict on version