### PR TITLE
Use generalized resize_to_limit

### DIFF
--- a/app/views/trestle/active_storage/_has_many_field.html.erb
+++ b/app/views/trestle/active_storage/_has_many_field.html.erb
@@ -5,10 +5,10 @@
         <% attachments.each do |attachment| %>
           <div class="active-storage__preview">
             <% if attachment.previewable? %>
-              <%= link_to image_tag(main_app.url_for(attachment.preview(resize: "300x300>")), class: "active-storage__image"),
+              <%= link_to image_tag(main_app.url_for(attachment.preview(resize_to_limit: [300, 300])), class: "active-storage__image"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.variable? %>
-              <%= link_to image_tag(main_app.url_for(attachment.variant(resize: "300x300>")), class: "active-storage__image"),
+              <%= link_to image_tag(main_app.url_for(attachment.variant(resize_to_limit: [300, 300])), class: "active-storage__image"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.persisted? %>
               <%= link_to main_app.rails_blob_path(attachment, disposition: "attachment"), class: "btn btn-info" do %>

--- a/app/views/trestle/active_storage/_has_one_field.html.erb
+++ b/app/views/trestle/active_storage/_has_one_field.html.erb
@@ -2,10 +2,10 @@
   <% if attachment.attached? && builder.object.persisted? %>
     <div class="active-storage__preview">
       <% if attachment.previewable? %>
-        <%= link_to image_tag(main_app.url_for(attachment.preview(resize: "300x300>")), class: "active-storage__image"),
+        <%= link_to image_tag(main_app.url_for(attachment.preview(resize_to_limit: [300, 300])), class: "active-storage__image"),
                     main_app.rails_blob_path(attachment, disposition: "attachment") %>
       <% elsif attachment.variable? %>
-        <%= link_to image_tag(main_app.url_for(attachment.variant(resize: "300x300>")), class: "active-storage__image"),
+        <%= link_to image_tag(main_app.url_for(attachment.variant(resize_to_limit: [300, 300])), class: "active-storage__image"),
                     main_app.rails_blob_path(attachment, disposition: "attachment") %>
       <% else %>
         <%= link_to main_app.rails_blob_path(attachment, disposition: "attachment"), class: "btn btn-info" do %>


### PR DESCRIPTION
We're using the `:vips` processor and image previews are currently broken since the gem is using the imagemagick-specific "300x300>" command.

There's a more general `resize_to_limit` method we can use instead, as documented [here](https://edgeapi.rubyonrails.org/classes/ActiveStorage/Variant.html).