### PR TITLE
Vips compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for Vips as active storage image processor ([#119](https://github.com/richardvenneman/trestle-active_storage/pull/119), closes [#110](https://github.com/richardvenneman/trestle-active_storage/issues/110)), (thanks [@timmitry](https://github.com/Timmitry)!)
+
 ## [3.0.1] - 2020-10-19
-- Display download link and delete checkbox only if attachment persisted (closes [#71](https://github.com/richardvenneman/trestle-active_storage/issues/71),  (thanks @oleg-kiviljov!)
+- Display download link and delete checkbox only if attachment persisted (closes [#71](https://github.com/richardvenneman/trestle-active_storage/issues/71), (thanks [@oleg-kiviljov](https://github.com/oleg-kiviljov)!)
 
 ## [3.0.0] - 2020-06-08
-- Rails 6 compatibility (closes [#41](https://github.com/richardvenneman/trestle-active_storage/issues/41), [#58](https://github.com/richardvenneman/trestle-active_storage/issues/58), thanks @McRipper!)
+- Rails 6 compatibility (closes [#41](https://github.com/richardvenneman/trestle-active_storage/issues/41), [#58](https://github.com/richardvenneman/trestle-active_storage/issues/58), thanks [@McRipper](https://github.com/mcripper)!)
 
 ## [2.2.1] - 2019-11-07
 ### Added
 - Add changelog
 
 ### Fixed
-- Workaround erroneous new records (closes [#31](https://github.com/richardvenneman/trestle-active_storage/issues/31), thanks @hoenth!)
+- Workaround erroneous new records (closes [#31](https://github.com/richardvenneman/trestle-active_storage/issues/31), thanks [@hoenth](https://github.com/hoenth)!)

--- a/app/views/trestle/active_storage/_has_many_field.html.erb
+++ b/app/views/trestle/active_storage/_has_many_field.html.erb
@@ -5,10 +5,10 @@
         <% attachments.each do |attachment| %>
           <div class="active-storage__preview">
             <% if attachment.previewable? %>
-              <%= link_to image_tag(main_app.url_for(attachment.preview(resize: "300x300>")), class: "active-storage__image"),
+              <%= link_to image_tag(main_app.url_for(attachment.preview(resize_to_limit: [300, 300])), class: "active-storage__image"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.variable? %>
-              <%= link_to image_tag(main_app.url_for(attachment.variant(resize: "300x300>")), class: "active-storage__image"),
+              <%= link_to image_tag(main_app.url_for(attachment.variant(resize_to_limit: [300, 300])), class: "active-storage__image"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.persisted? %>
               <%= link_to main_app.rails_blob_path(attachment, disposition: "attachment"), class: "btn btn-info" do %>

--- a/app/views/trestle/active_storage/_has_one_field.html.erb
+++ b/app/views/trestle/active_storage/_has_one_field.html.erb
@@ -2,10 +2,10 @@
   <% if attachment.attached? && builder.object.persisted? %>
     <div class="active-storage__preview">
       <% if attachment.previewable? %>
-        <%= link_to image_tag(main_app.url_for(attachment.preview(resize: "300x300>")), class: "active-storage__image"),
+        <%= link_to image_tag(main_app.url_for(attachment.preview(resize_to_limit: [300, 300])), class: "active-storage__image"),
                     main_app.rails_blob_path(attachment, disposition: "attachment") %>
       <% elsif attachment.variable? %>
-        <%= link_to image_tag(main_app.url_for(attachment.variant(resize: "300x300>")), class: "active-storage__image"),
+        <%= link_to image_tag(main_app.url_for(attachment.variant(resize_to_limit: [300, 300])), class: "active-storage__image"),
                     main_app.rails_blob_path(attachment, disposition: "attachment") %>
       <% else %>
         <%= link_to main_app.rails_blob_path(attachment, disposition: "attachment"), class: "btn btn-info" do %>


### PR DESCRIPTION
Active storage / the [image processing gem](https://github.com/janko/image_processing) allows to either use Imagemagick or Vips for transforming images. Rails 7 changes the [default processor to Vips](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-storage-default-variant-processor-changed-to-vips).

Vips is not 100% compatible with Imagemagick, so some usages need to be adapted. This gem uses `resize: "300x300>"`, which, as far as [I understood the examples](https://legacy.imagemagick.org/Usage/resize/#resize), means:

- Only shrink the image, do not enlarge (">" operator)
- Keep the aspect ratio
- Make the image fit into a box of 300x300 pixels - which means that the final size could be e.g. 200x300 pixels.

This should correspond to the [`resize_to_limit` option](https://github.com/janko/image_processing/blob/master/doc/vips.md#resize_to_limit), which has the same API for both Vips and ImageMagick. Note that the Array-Syntax `[300, 300]` is required for Vips (while `"300x300"` would still be possible for ImageMagick).