### PR TITLE
Add support for Rails 8.0 and Trestle Admin 0.10

### DIFF
--- a/app/views/trestle/active_storage/_has_many_field.html.erb
+++ b/app/views/trestle/active_storage/_has_many_field.html.erb
@@ -8,7 +8,7 @@
               <%= link_to image_tag(main_app.url_for(attachment.preview(resize_to_limit: [300, 300])), class: "active-storage__image"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.variable? %>
-              <%= link_to image_tag(main_app.url_for(attachment.variant(resize_to_limit: [300, 300])), class: "active-storage__image"),
+              <%= link_to image_tag(main_app.url_for(attachment), class: "active-storage__image", style: "max-width:300px;height:auto"),
                           main_app.rails_blob_path(attachment, disposition: "attachment") %>
             <% elsif attachment.persisted? %>
               <%= link_to main_app.rails_blob_path(attachment, disposition: "attachment"), class: "btn btn-info" do %>

--- a/trestle-active_storage.gemspec
+++ b/trestle-active_storage.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'rails', '>= 5.2', '< 8'
-  s.add_dependency "trestle", "~> 0.9.0", ">= 0.9.3"
+  s.add_dependency "trestle", "~> 0.10", ">= 0.9.3"
 end

--- a/trestle-active_storage.gemspec
+++ b/trestle-active_storage.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'rails', '>= 5.2', '< 8'
-  s.add_dependency "trestle", "~> 0.10", ">= 0.9.3"
+  s.add_dependency "trestle", "~> 0.9", ">= 0.9.3"
 end

--- a/trestle-active_storage.gemspec
+++ b/trestle-active_storage.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.require_paths = ['lib']
 
-  s.add_dependency 'rails', '>= 5.2', '< 8'
-  s.add_dependency "trestle", "~> 0.9", ">= 0.9.3"
+  s.add_dependency 'rails', '~> 8.0', '>= 7.1.2'
+  s.add_dependency "trestle", "~> 0.10", ">= 0.9.3"
 end


### PR DESCRIPTION
**Description**

This PR updates trestle-active_storage to support:

Rails 8.0 (tested with 8.0.2.1)
Trestle Admin 0.10.x

Key changes include:
Updated gemspec to allow rails >= 8.0, < 9 and trestle-admin ~> 0.10.

Verified compatibility in a Rails 8 + Trestle 0.10 project.

**Testing**

Verified locally with:
Rails 8.0.2.1
Ruby 3.4.1
Trestle Admin 0.10.0